### PR TITLE
fix:判断layoutTopContextsAfter方法currentLine为空

### DIFF
--- a/src/View/View.ts
+++ b/src/View/View.ts
@@ -94,11 +94,13 @@ export class View {
     }
 
     private static layoutTopContextsAfter(currentLine: Line.ValueObject) {
-        while (currentLine.next.isSome) {
+        if(currentLine) {
+            while (currentLine.next.isSome) {
+                currentLine.topContext.update();
+                currentLine = currentLine.next.toNullable()!;
+            }
             currentLine.topContext.update();
-            currentLine = currentLine.next.toNullable()!;
         }
-        currentLine.topContext.update();
     }
 
     private constructLabelViewsForLine(line: Line.ValueObject): Array<LabelView.Entity> {


### PR DESCRIPTION
当currentLine变量为undefined情况下，currentLine.next导致删除文本文字时光标位置错误，并且控制台报错。